### PR TITLE
provide option to change upload button label

### DIFF
--- a/app/models/inputs/asset_box.rb
+++ b/app/models/inputs/asset_box.rb
@@ -84,7 +84,8 @@ module Inputs
           :file_types => @options[:file_types],
           :progress_bar_partial => @options[:progress_bar_partial],
           :drop_files => @options[:uploader_drop_files],
-          :aws_acl => @options[:aws_acl]
+          :aws_acl => @options[:aws_acl],
+          :btn_label => @options[:btn_label]
         }
       ).html_safe
     end
@@ -147,7 +148,8 @@ module Inputs
         :dialog_url => @template.effective_assets.effective_assets_path,
         :disabled => false,
         :file_types => [:any],
-        :aws_acl => EffectiveAssets.aws_acl
+        :aws_acl => EffectiveAssets.aws_acl,
+        :btn_label => "Upload files..."
       }.merge(opts).tap do |options|
         options[:method] = method.to_s
         options[:box] = method.to_s.pluralize

--- a/app/views/asset_box_input/_uploader.html.haml
+++ b/app/views/asset_box_input/_uploader.html.haml
@@ -7,7 +7,7 @@
 
   %span.btn.btn-success.fileinput-button
     %i.glyphicon.glyphicon-upload
-    %span Upload files...
+    %span= btn_label
     - if limit > 1
       %input{:type => 'file', :name => 'file', :multiple => 'multiple', :disabled => disabled}
     - else


### PR DESCRIPTION
I want to use "Browse" as the label for the "Upload files..." button.  I think "Browse" is probably a better default but it is nice to have the config option for this in any case.  I don't particularly like the config name `btn_label` but it is descriptive and I couldn't think of a better name that wasn't excessively long.