### PR TITLE
splash Dir array for ActiveAdmin load_pahts

### DIFF
--- a/lib/effective_assets/engine.rb
+++ b/lib/effective_assets/engine.rb
@@ -38,7 +38,7 @@ module EffectiveAssets
     # This prepends the load path so someone can override the assets.rb if they want.
     initializer 'effective_assets.active_admin' do
       if defined?(ActiveAdmin) && EffectiveAssets.use_active_admin == true
-        ActiveAdmin.application.load_paths.unshift Dir["#{config.root}/active_admin"]
+        ActiveAdmin.application.load_paths.unshift *Dir["#{config.root}/active_admin"]
       end
     end
 


### PR DESCRIPTION
Current situation:
```ruby
ActiveAdmin.application.load_paths
# => ["/path/to/the/rails_app/app/admin"]

ActiveAdmin.application.load_paths.unshift Dir["#{config.root}/active_admin"]

ActiveAdmin.application.load_paths
# => [["/path/to/the/gems/effective_assets/active_admin"], "/path/to/the/rails_app/app/admin"]
```
The problem is `Dir` returns an Array and `unshift` puts this `Array` in front of the `load_paths`, but `load_paths` can only contain `Strings` and not `Array` of `Strings`.

After my fix it looks like:
```ruby
ActiveAdmin.application.load_paths
# => ["/path/to/the/rails_app/app/admin"]

ActiveAdmin.application.load_paths.unshift *Dir["#{config.root}/active_admin"]

ActiveAdmin.application.load_paths
# => ["/path/to/the/gems/effective_assets/active_admin", "/path/to/the/rails_app/app/admin"]
```
Now `unshift` puts the elements of the `Dir` returned `Array` in front of the `load_paths`.

This will fix #5 and activeadmin/activeadmin#3906.