### PR TITLE
correct count on delete

### DIFF
--- a/app/assets/javascripts/effective_assets/asset_box.js.coffee
+++ b/app/assets/javascripts/effective_assets/asset_box.js.coffee
@@ -3,34 +3,22 @@ $(document).on 's3_file_added', (event, file) ->
   obj.closest('.error').removeClass('error')
   obj.parent().siblings('.help-inline,.inline-errors').remove()
 
-$(document).on 's3_uploads_complete', (_, uploader) -> 
+$(document).on 's3_uploads_complete', (_, uploader) ->
   uploader.closest('.asset-box-input').find('.filter-attachments').val('')
 
-$(document).on 's3_upload_failed', (_, uploader, content) -> 
+$(document).on 's3_upload_failed', (_, uploader, content) ->
   uploader.closest('.asset-box-input').find('.filter-attachments').val('')
   alert("An error occurred while uploading #{content.filename}.\n\nThe returned error message is: '#{content.error_thrown}'\n\nPlease try again.")
 
 $(document).on 'click', 'a.attachment-remove', (event) ->
   event.preventDefault()
-  attachment_div = $(event.target).closest('.attachment')
+  $attachmentDiv = $(event.target).closest('.attachment')
 
-  attachment_div.find('input.asset-box-remove').first().val(1)
-  attachment_div.hide()
+  $attachmentDiv.find('input.asset-box-remove').first().val(1)
+  $attachmentDiv.hide()
 
-  # Show the first 'limit' attachments, hide the rest
-  asset_box_input = attachment_div.closest('div.asset-box-input')
-  limit = asset_box_input.data('limit')
-
-  asset_box_input.find("input.asset-box-remove").each (index) ->
-    if "#{$(this).val()}" == '1' # If we're going to delete it...
-      $(this).closest('.attachment').hide()
-      limit = limit + 1
-      return
-
-    if index >= limit
-      $(this).closest('.attachment').hide()
-    else
-      $(this).closest('.attachment').show()
-
-
+  # Correct the attachment count
+  $assetBoxInput = $attachmentDiv.closest('div.asset-box-input')
+  count = parseInt($assetBoxInput.attr('data-attachment-count'), 10)
+  $assetBoxInput.attr('data-attachment-count', count - 1)
 


### PR DESCRIPTION
This PR removes behavior that hides and shows uploads beyond the limit.

Adding an update to attachment count on JS delete.  This only applies to the `attachment_actions: [:insert, :delete]` is not used.  With the `delete` action included, the delete action causes a page refresh and the entire upload is lost (a bug?).