### PR TITLE
change browse button to secondary button

### DIFF
--- a/app/views/asset_box_input/_uploader.html.haml
+++ b/app/views/asset_box_input/_uploader.html.haml
@@ -5,7 +5,7 @@
   - if drop_files
     %p= drop_files_help_text
 
-  %span.btn.btn-success.fileinput-button
+  %span.btn.btn-secondary.fileinput-button
     %i.glyphicon.glyphicon-upload
     %span= btn_label
     - if limit > 1


### PR DESCRIPTION
The browse button in the drag and drop uploader is not a confirmation type button so it shouldn't have a class of `btn-success`.  It is also not a form submit button (eliminating `btn-primary`).  This button makes the most sense as a `btn-secondary`.  What do you think?