### PR TITLE
set attachment title based on input if new attachment

### DIFF
--- a/app/assets/javascripts/effective/snippets/effective_asset.js.coffee.erb
+++ b/app/assets/javascripts/effective/snippets/effective_asset.js.coffee.erb
@@ -20,8 +20,20 @@ CKEDITOR.dialog.add 'effective_asset', (editor) ->
 
               $(this).contents().on 'click', 'a.attachment-insert', (event) ->
                 event.preventDefault()
-                dialog.setValueOf('asset', 'asset_id', $(event.currentTarget).data('asset-id'))
-                dialog.setValueOf('asset', 'link_title', $($(event.currentTarget).data('asset')).text())
+                linkTitle = $($(event.currentTarget).data('asset')).text()
+
+                currentAssetId = dialog.getValueOf('asset', 'asset_id')
+                newAssetId = $(event.currentTarget).data('asset-id')
+                # if changing or initializing the attachment
+                if currentAssetId != newAssetId
+                  dialog.setValueOf('asset', 'asset_id', newAssetId)
+                  # if initializing the attachment
+                  if currentAssetId == ''
+                    # try to set the link title based on a given link title
+                    givenLinkTitle = dialog.getContentElement('asset', 'link_title').getValue()
+                    linkTitle = givenLinkTitle if givenLinkTitle.length > 0
+
+                dialog.setValueOf('asset', 'link_title', linkTitle)
                 dialog.commitContent()
                 dialog.click('ok')
         }

--- a/app/views/effective/snippets/_effective_asset.html.haml
+++ b/app/views/effective/snippets/_effective_asset.html.haml
@@ -6,4 +6,5 @@
 - elsif asset.image?
   = effective_asset_image_tag(asset, nil, :class => effective_asset.html_class)
 - else
-  = effective_asset_link_to(asset, nil, :class => effective_asset.html_class, :title => effective_asset.link_title.presence)
+  %span.effective-assets-asset-link{data: {'content-type' => asset.content_type}}
+    = effective_asset_link_to(asset, nil, :class => effective_asset.html_class, :title => effective_asset.link_title.presence)


### PR DESCRIPTION
As a content admin, I would like to add an attachment to an editable page and change the link title from the filename in one step so that I don't have to edit the attachment details twice.

Currently, the filename doesn't change if you edit it at the same time as adding it.

In this PR, I ignore using the given link title unless the attachment is new because otherwise when you change the attachment, it is difficult to realize that the attachment changed since the link title didn't change.

If it is possible to get the saved link title then we could check to see if the link title was updated at the same time as the new attachment but I could not figure out how to do that.