### PR TITLE
fix issue with symbolic object names using SimpleForm

### DIFF
--- a/app/views/asset_box_input/_attachment_as_list.html.haml
+++ b/app/views/asset_box_input/_attachment_as_list.html.haml
@@ -13,8 +13,8 @@
       %img{:src => asset_path('effective_assets/icon_close.png'), :alt => 'Remove'}
 
   - if attachment.persisted?
-    = hidden_field_tag(attachable_object_name + "[attachments_attributes][#{uid}][id]", attachment.id)
-  = hidden_field_tag(attachable_object_name + "[attachments_attributes][#{uid}][asset_id]", attachment.asset_id)
-  = hidden_field_tag(attachable_object_name + "[attachments_attributes][#{uid}][box]", attachment.box)
-  = hidden_field_tag(attachable_object_name + "[attachments_attributes][#{uid}][_destroy]", attachment.marked_for_destruction? ? 1 : nil, :class => 'asset-box-remove')
-  = hidden_field_tag(attachable_object_name + "[attachments_attributes][#{uid}][position]", 1)
+    = hidden_field_tag("#{attachable_object_name}[attachments_attributes][#{uid}][id]", attachment.id)
+  = hidden_field_tag("#{attachable_object_name}[attachments_attributes][#{uid}][asset_id]", attachment.asset_id)
+  = hidden_field_tag("#{attachable_object_name}[attachments_attributes][#{uid}][box]", attachment.box)
+  = hidden_field_tag("#{attachable_object_name}[attachments_attributes][#{uid}][_destroy]", attachment.marked_for_destruction? ? 1 : nil, :class => 'asset-box-remove')
+  = hidden_field_tag("#{attachable_object_name}[attachments_attributes][#{uid}][position]", 1)

--- a/app/views/asset_box_input/_attachment_as_table.html.haml
+++ b/app/views/asset_box_input/_attachment_as_table.html.haml
@@ -30,7 +30,8 @@
         %i.glyphicon.glyphicon-trash
 
     - if attachment.persisted?
-      = hidden_field_tag(attachable_object_name + "[attachments_attributes][#{uid}][id]", attachment.id)
-    = hidden_field_tag(attachable_object_name + "[attachments_attributes][#{uid}][asset_id]", attachment.asset_id)
-    = hidden_field_tag(attachable_object_name + "[attachments_attributes][#{uid}][box]", attachment.box)
-    = hidden_field_tag(attachable_object_name + "[attachments_attributes][#{uid}][_destroy]", attachment.marked_for_destruction? ? 1 : nil, :class => 'asset-box-remove')
+      = hidden_field_tag("#{attachable_object_name}[attachments_attributes][#{uid}][id]", attachment.id)
+    = hidden_field_tag("#{attachable_object_name}[attachments_attributes][#{uid}][asset_id]", attachment.asset_id)
+    = hidden_field_tag("#{attachable_object_name}[attachments_attributes][#{uid}][box]", attachment.box)
+    = hidden_field_tag("#{attachable_object_name}[attachments_attributes][#{uid}][_destroy]", attachment.marked_for_destruction? ? 1 : nil, :class => 'asset-box-remove')
+    = hidden_field_tag("#{attachable_object_name}[attachments_attributes][#{uid}][position]", 1)

--- a/app/views/asset_box_input/_attachment_as_thumbnail.html.haml
+++ b/app/views/asset_box_input/_attachment_as_thumbnail.html.haml
@@ -16,8 +16,8 @@
         %img{:src => asset_path('effective_assets/icon_close.png'), :alt => 'Remove'}
 
     - if attachment.persisted?
-      = hidden_field_tag(attachable_object_name + "[attachments_attributes][#{uid}][id]", attachment.id)
-    = hidden_field_tag(attachable_object_name + "[attachments_attributes][#{uid}][asset_id]", attachment.asset_id)
-    = hidden_field_tag(attachable_object_name + "[attachments_attributes][#{uid}][box]", attachment.box)
-    = hidden_field_tag(attachable_object_name + "[attachments_attributes][#{uid}][_destroy]", attachment.marked_for_destruction? ? 1 : nil, :class => 'asset-box-remove')
-    = hidden_field_tag(attachable_object_name + "[attachments_attributes][#{uid}][position]", 1)
+      = hidden_field_tag("#{attachable_object_name}[attachments_attributes][#{uid}][id]", attachment.id)
+    = hidden_field_tag("#{attachable_object_name}[attachments_attributes][#{uid}][asset_id]", attachment.asset_id)
+    = hidden_field_tag("#{attachable_object_name}[attachments_attributes][#{uid}][box]", attachment.box)
+    = hidden_field_tag("#{attachable_object_name}[attachments_attributes][#{uid}][_destroy]", attachment.marked_for_destruction? ? 1 : nil, :class => 'asset-box-remove')
+    = hidden_field_tag("#{attachable_object_name}[attachments_attributes][#{uid}][position]", 1)


### PR DESCRIPTION
I was using an asset uploader on an Admin form using simple_form (`simple_form_for [:admin, user]`) and getting this error where no error exists for the same input on a non-admin form:

`ActionView::Template::Error (undefined method '+' for :user:Symbol)`

```
effective_assets (1.4.9) app/views/asset_box_input/_attachment_as_thumbnail.html.haml:19:in `___sers_nathan__rvm_gems_ruby________lam_allery_gems_effective_assets_______app_views_asset_box_input__attachment_as_thumbnail_html_haml__308308914485762670_70167524492620'
actionview (4.2.1) lib/action_view/template.rb:145:in `block in render'
activesupport (4.2.1) lib/active_support/notifications.rb:166:in `instrument'
```

